### PR TITLE
Updated text in LCM banner

### DIFF
--- a/web/modules/custom/cj/src/Plugin/Block/LuovaBlock.php
+++ b/web/modules/custom/cj/src/Plugin/Block/LuovaBlock.php
@@ -24,9 +24,9 @@ class LuovaBlock extends BlockBase {
 <img src="/'.drupal_get_path('theme', 'cj_material').'/assets/lcmlogo.png" class="lcm-banner-logo" />
 </div>
 <div class="col col-xs-12 col-md-9 lcm-banner-text">
-<h2>Are you ready for a new fundraising opportunity?</h2>
+<h2>Are you ready for a new opportunity in London?</h2>
 
-<p><span>Christian Jobs are currently recruiting for London City Mission, a London-focused Christian organisation equipping missionaries to reach the streets of London who are looking to expand their fundraising team through a number of opportunities. If you are a fundraiser, or know someone who may be interested in one of these new and exciting opportunities, contact our recruitment team to find out more!</span></p>
+<p><span>Christian Jobs are currently recruiting for London City Mission, a London-focused Christian organisation equipping missionaries to reach the streets of London who are looking to expand their team through a number of opportunities. If you or someone you know are interested in one of these new and exciting opportunities, contact our recruitment team to find out more!</span></p>
 <a class="btn" href="https://www.christianjobs.co.uk/employer/54">Find out more</a></div>
 </div>';
     return $content;


### PR DESCRIPTION
As per JS/LR request, I've updated the text in the homepage banner to advertise general LCM vacancies rather than being fundraising specific:

![Screenshot 2021-05-17 at 08 58 02 (2)](https://user-images.githubusercontent.com/58986635/118453061-b4663180-b6ee-11eb-9647-30618599217c.png)

![Screenshot 2021-05-17 at 08 58 18 (2)](https://user-images.githubusercontent.com/58986635/118453076-b7f9b880-b6ee-11eb-973c-5bca1791f831.png)

![Screenshot 2021-05-17 at 08 58 28 (2)](https://user-images.githubusercontent.com/58986635/118453086-ba5c1280-b6ee-11eb-91e3-45c4a4f8ef86.png)